### PR TITLE
Feat/info

### DIFF
--- a/cmd/gommitizen/cmd/projects.go
+++ b/cmd/gommitizen/cmd/projects.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/freepik-company/gommitizen/internal/config"
+)
+
+type projectsOpts struct {
+	directory       string
+	projectPrefix   string
+	showVersionOnly bool
+	showProjectPath bool
+	outputFormat    string
+}
+
+func Projects() *cobra.Command {
+	var opts = projectsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "projects",
+		Short: "Give a list of projects, their versions and other information",
+		Run: func(cmd *cobra.Command, args []string) {
+			projectsRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.directory, "directory", "d", "", "select a project directory to retrieve the project information")
+	cmd.Flags().StringVarP(&opts.projectPrefix, "prefix", "p", "", "select a prefix to look for projects. Don't use with --directory")
+	cmd.Flags().BoolVarP(&opts.showVersionOnly, "version", "v", false, "show only the version of the projects")
+	cmd.Flags().BoolVarP(&opts.showProjectPath, "path", "P", false, "show only the path of the projects")
+	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "plain", "select the output format {json, yaml, plain}")
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if opts.directory != "" && opts.projectPrefix != "" {
+			return fmt.Errorf("flags --directory and --prefix are mutually exclusive")
+		}
+
+		if opts.outputFormat != "json" && opts.outputFormat != "yaml" && opts.outputFormat != "plain" {
+			return fmt.Errorf("invalid output format: %s, supported values: json, yaml, plain", opts.outputFormat)
+		}
+
+		if (opts.showVersionOnly || opts.showProjectPath) && opts.outputFormat != "plain" {
+			return fmt.Errorf("flags --version and --path can only be used with plain format")
+		}
+
+		return nil
+	}
+
+	return cmd
+}
+
+func projectsRun(opts projectsOpts) {
+	var configVersionPaths []string
+
+	if opts.projectPrefix == "" {
+		nDirPath, err := config.NormalizePath(opts.directory)
+		if err != nil {
+			slog.Error(fmt.Sprintf("normalising folders: %v", err))
+			os.Exit(1)
+		}
+
+		configVersionPaths, err = config.FindConfigVersionFilePath(nDirPath)
+		if err != nil {
+			slog.Error(fmt.Sprintf("finding config version file path: %v", err))
+			os.Exit(1)
+		}
+	} else {
+		nDirPath, err := config.NormalizePath(opts.directory)
+		if err != nil {
+			slog.Error(fmt.Sprintf("normalising folders: %v", err))
+			os.Exit(1)
+		}
+
+		configVersionPaths, err = config.FindConfigVersionFilePathByPrefix(nDirPath, opts.projectPrefix)
+		if err != nil {
+			slog.Error(fmt.Sprintf("finding config version file path by prefix: %v", err))
+			os.Exit(1)
+		}
+	}
+
+	if len(configVersionPaths) == 0 {
+		slog.Info("No projects found")
+		os.Exit(0)
+	}
+
+	var configVersions []*config.ConfigVersion
+	for _, configVersionPath := range configVersionPaths {
+		configVersionFile, err := config.ReadConfigVersion(configVersionPath)
+		if err != nil {
+			slog.Error(fmt.Sprintf("reading configVersionFile version: %v", err))
+			continue
+		}
+		configVersions = append(configVersions, configVersionFile)
+	}
+
+	var printOption config.PrintPlainOption
+	var err error
+	if opts.outputFormat == "plain" {
+		if opts.showVersionOnly {
+			printOption = config.PrintVersionOnly
+		} else if opts.showProjectPath {
+			printOption = config.PrintPathOnly
+		} else {
+			printOption = config.PrintAll
+		}
+		err = config.PrintConfigVersionsPlain(configVersions, printOption)
+	} else {
+		err = config.PrintConfigVersions(configVersions, opts.outputFormat)
+	}
+
+	if err != nil {
+		slog.Error(fmt.Sprintf("printing config versions: %v", err))
+		os.Exit(1)
+	}
+}

--- a/cmd/gommitizen/main.go
+++ b/cmd/gommitizen/main.go
@@ -42,6 +42,7 @@ Currently it only supports the bump command, but it will support the commit comm
 
 	root.AddCommand(cmd.Init())
 	root.AddCommand(cmd.Bump())
+	root.AddCommand(cmd.Projects())
 
 	err := root.Execute()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,13 +1,24 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
 
 const (
 	defaultFileName = ".version.json"
+)
+
+type PrintPlainOption int
+
+const (
+	PrintAll PrintPlainOption = iota
+	PrintPathOnly
+	PrintVersionOnly
 )
 
 func NormalizePath(dirPath string) (string, error) {
@@ -44,15 +55,110 @@ func isRelativeDirPath(path string) bool {
 func FindConfigVersionFilePath(path string) ([]string, error) {
 	var list []string
 
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(path, func(subpath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if !info.IsDir() && info.Name() == defaultFileName {
-			list = append(list, path)
+			list = append(list, subpath)
 		}
 		return nil
 	})
 
 	return list, err
+}
+
+func FindConfigVersionFilePathByPrefix(path, tag_prefix string) ([]string, error) {
+	var list []string
+
+	err := filepath.Walk(path, func(subpath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking subpath: %v", err)
+		}
+		if !info.IsDir() && info.Name() == defaultFileName {
+			file, err := os.Open(subpath)
+			if err != nil {
+				return fmt.Errorf("error opening file: %v", err)
+			}
+			defer func(file *os.File) {
+				err := file.Close()
+				if err != nil {
+					slog.Error(fmt.Sprintf("error closing file: %v", err))
+				}
+			}(file)
+
+			var data map[string]interface{}
+			if err := json.NewDecoder(file).Decode(&data); err != nil {
+				return fmt.Errorf("error decoding file: %v", err)
+			}
+
+			if dataPrefix, ok := data["tag_prefix"].(string); ok && dataPrefix == tag_prefix {
+				list = append(list, subpath)
+			}
+		}
+		return nil
+	})
+
+	return list, err
+}
+
+func PrintConfigVersions(configVersions []*ConfigVersion, format string) error {
+	var err error
+
+	switch format {
+	case "json":
+		err = printConfigVersionsJSON(configVersions)
+	case "yaml":
+		err = printConfigVersionsYAML(configVersions)
+	}
+	if err != nil {
+		return fmt.Errorf("error printing config versions: %v", err)
+	}
+	return nil
+}
+
+func printConfigVersionsJSON(configVersions []*ConfigVersion) error {
+	obj := make(map[string]interface{})
+	obj["config_versions"] = configVersions
+
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling data: %v", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func printConfigVersionsYAML(configVersions []*ConfigVersion) error {
+	obj := make(map[string]interface{})
+	obj["config_versions"] = configVersions
+
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("error marshalling data: %v", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func PrintConfigVersionsPlain(configVersions []*ConfigVersion, option PrintPlainOption) error {
+	for _, configVersion := range configVersions {
+		switch option {
+		case PrintPathOnly:
+			fmt.Printf("%s: %s\n", configVersion.TagPrefix, configVersion.GetDirPath())
+		case PrintVersionOnly:
+			fmt.Printf("%s: %s\n", configVersion.TagPrefix, configVersion.Version)
+		case PrintAll:
+			fmt.Println("Tag Prefix:", configVersion.TagPrefix)
+			fmt.Println("Directory:", configVersion.GetDirPath())
+			fmt.Println("Version:", configVersion.Version)
+			fmt.Println("Commit:", configVersion.Commit)
+			fmt.Println("Version Files:")
+			for _, file := range configVersion.VersionFiles {
+				fmt.Println(" -", file)
+			}
+			fmt.Println()
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Support for printing `.version.json` information from projects.

It supports printing in YAML and JSON format. For automation purposes, it also allows printing in plain format and shows only the directory path or the project's current version.