### PR TITLE
feat(Makefile): Introduce version bumping options and improve release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,16 @@ uninstall:  ## Uninstall gommitizen
 bump: ## Bump version using commitizen
 	cz bump
 
-release: ## Release new version
+bump-alpha: ## Bump version using commitizen (alpha)
+	cz bump -pr alpha
+
+bump-beta: ## Bump version using commitizen (beta)
+	cz bump -pr beta
+
+bump-rc: ## Bump version using commitizen (release candidate)
+	cz bump -pr rc
+
+release: bump ## Release new version
 	goreleaser release
 
 test-release: ## Test release new version


### PR DESCRIPTION
- Modify Makefile to utilize commitizen for version bumps (alpha, beta, rc)
- Implement new "bump" target in Makefile to update the version automatically
- Update "release" target to trigger a version bump before releasing
- Add new targets "bump-alpha", "bump-beta", and "bump-rc" for specific version bumps
- Refactor existing "release" target to call the new "bump" target
