### PR TITLE
fix(internal/pkg/cmd/get.go): Enhance output handling for structured formats

### DIFF
--- a/internal/pkg/cmd/get.go
+++ b/internal/pkg/cmd/get.go
@@ -149,5 +149,11 @@ func projectsRun(dirPath string, alias string, output string, filter []string) {
 		slog.Error(fmt.Sprintf("printing config versions: %v", err))
 		os.Exit(1)
 	}
-	slog.Info(str)
+
+	// Print directly to stdout for structured formats to allow piping to tools like yq
+	if output == "json" || output == "yaml" {
+		fmt.Println(str)
+	} else {
+		slog.Info(str)
+	}
 }


### PR DESCRIPTION
# Improve output handling for structured formats in get command

## Summary
This PR enhances the `get` command to print structured output formats (JSON and YAML) directly to stdout instead of using the structured logger. This change improves compatibility with command-line tools like `yq` and other processors that expect clean structured data in their input pipeline.

## Changes
- Modified the `projectsRun` function to output JSON and YAML formats directly to stdout using `fmt.Println`
- Maintained the original behavior for the plain text format which continues to use the structured logger

## Benefits
- Enables seamless piping of structured output to other command-line tools
- Makes it easier to parse and manipulate the output programmatically
- Respects standard CLI conventions where structured data goes to stdout without logger metadata

## Example usage
```shell
# Now you can easily pipe JSON output to jq
gommitizen get all -o json | jq '.projects[0].version'

# Or pipe YAML output to yq
gommitizen get all -o yaml | yq '.projects[0].version'
```

## Testing
The change has been tested with various tools to ensure proper integration.
