### PR TITLE
fix(version): handle quoted YAML values in version_files

### DIFF
--- a/internal/app/gommitizen/config/output.go
+++ b/internal/app/gommitizen/config/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -21,7 +22,11 @@ type Wrapper struct {
 }
 
 func PrintConfigVersions(configVersions []*ConfigVersion, fields []string, outputFormat string) (string, error) {
-	wrapper := configVersionFilter(configVersions, fields, outputFormat)
+	tagFormat := outputFormat
+	if tagFormat == "raw" {
+		tagFormat = "plain"
+	}
+	wrapper := configVersionFilter(configVersions, fields, tagFormat)
 
 	switch outputFormat {
 	case "json":
@@ -30,6 +35,8 @@ func PrintConfigVersions(configVersions []*ConfigVersion, fields []string, outpu
 		return printConfigVersionsYAML(wrapper)
 	case "plain":
 		return printConfigVersionsPlain(wrapper)
+	case "raw":
+		return printConfigVersionsRaw(wrapper)
 	}
 
 	return "", fmt.Errorf("unsupported format: %s", outputFormat)
@@ -72,6 +79,46 @@ func printConfigVersionsPlain(wrapper Wrapper) (string, error) {
 	}
 
 	return sb.String(), nil
+}
+
+func printConfigVersionsRaw(wrapper Wrapper) (string, error) {
+	var lines []string
+	single := len(wrapper.ConfigVersionWrappers) == 1
+
+	for _, cvw := range wrapper.ConfigVersionWrappers {
+		alias, _ := cvw.ConfigVersion["alias"]
+
+		// Collect sorted non-alias keys for deterministic output
+		var keys []string
+		for key := range cvw.ConfigVersion {
+			if key != "alias" {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+
+		var line string
+		if len(keys) == 0 {
+			// Only alias field was requested (e.g., "get alias")
+			line = fmt.Sprintf("%v", alias)
+		} else if len(keys) == 1 {
+			line = fmt.Sprintf("%v", cvw.ConfigVersion[keys[0]])
+		} else {
+			// Multiple fields: join as key:value pairs
+			var pairs []string
+			for _, key := range keys {
+				pairs = append(pairs, fmt.Sprintf("%s:%v", key, cvw.ConfigVersion[key]))
+			}
+			line = strings.Join(pairs, ",")
+		}
+
+		if !single {
+			line = fmt.Sprintf("%v=%s", alias, line)
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n"), nil
 }
 
 func configVersionFilter(configVersions []*ConfigVersion, fields []string, outputFormat string) Wrapper {

--- a/internal/app/gommitizen/config/version.go
+++ b/internal/app/gommitizen/config/version.go
@@ -163,37 +163,38 @@ func (v *ConfigVersion) UpdateVersion(newVersion string, lastCommit string) ([]s
 		substring := versionFile[index+1:]
 		filePath := filepath.Join(v.dirPath, fileName)
 
-		modified, err := updateVersionOfFiles(filePath, substring, newVersion)
+		matched, modified, err := updateVersionOfFiles(filePath, substring, newVersion)
 		if err != nil {
 			return nil, err
 		}
 		if modified {
 			modifiedFiles = append(modifiedFiles, filePath)
-		} else {
+		} else if !matched {
 			slog.Warn(fmt.Sprintf("version pattern not found in %s for key '%s'", filePath, substring))
+		} else {
+			slog.Info(fmt.Sprintf("version already up to date in %s for key '%s'", filePath, substring))
 		}
 	}
 
 	return modifiedFiles, nil
 }
 
-func updateVersionOfFiles(filePath, substring, newVersion string) (bool, error) {
+func updateVersionOfFiles(filePath, substring, newVersion string) (matched bool, modified bool, err error) {
 	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	var lines []string
-	modified := false
 
 	// Regular expression to find the version in the file
 	regularExpression := ""
 	validRegexp, err := isARegExp(substring)
 	// Check if the substring is a regular expression that compiles
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if validRegexp { // If it is a regular expression, use it as is
 		regularExpression = substring
@@ -202,13 +203,14 @@ func updateVersionOfFiles(filePath, substring, newVersion string) (bool, error) 
 	}
 	versionRegex, err := regexp.Compile(regularExpression)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	for scanner.Scan() {
 		line := scanner.Text()
 		match := versionRegex.FindStringSubmatch(line)
 		if len(match) > 1 {
+			matched = true
 			// The line contains the substring given by 'substring'
 			oldVersion := strings.TrimSpace(match[1])
 			// Replace the old version with the new version
@@ -223,14 +225,16 @@ func updateVersionOfFiles(filePath, substring, newVersion string) (bool, error) 
 		}
 	}
 
-	// Write the updated lines back to the file
-	file.Truncate(0)
-	file.Seek(0, 0)
-	for _, line := range lines {
-		file.WriteString(line + "\n")
+	// Only rewrite the file if changes were actually made
+	if modified {
+		file.Truncate(0)
+		file.Seek(0, 0)
+		for _, line := range lines {
+			file.WriteString(line + "\n")
+		}
 	}
 
-	return modified, nil
+	return matched, modified, nil
 }
 
 func isARegExp(s string) (bool, error) {

--- a/internal/app/gommitizen/config/version.go
+++ b/internal/app/gommitizen/config/version.go
@@ -163,41 +163,46 @@ func (v *ConfigVersion) UpdateVersion(newVersion string, lastCommit string) ([]s
 		substring := versionFile[index+1:]
 		filePath := filepath.Join(v.dirPath, fileName)
 
-		err := updateVersionOfFiles(filePath, substring, newVersion)
+		modified, err := updateVersionOfFiles(filePath, substring, newVersion)
 		if err != nil {
 			return nil, err
 		}
-		modifiedFiles = append(modifiedFiles, filePath)
+		if modified {
+			modifiedFiles = append(modifiedFiles, filePath)
+		} else {
+			slog.Warn(fmt.Sprintf("version pattern not found in %s for key '%s'", filePath, substring))
+		}
 	}
 
 	return modifiedFiles, nil
 }
 
-func updateVersionOfFiles(filePath, substring, newVersion string) error {
+func updateVersionOfFiles(filePath, substring, newVersion string) (bool, error) {
 	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	var lines []string
+	modified := false
 
 	// Regular expression to find the version in the file
 	regularExpression := ""
 	validRegexp, err := isARegExp(substring)
 	// Check if the substring is a regular expression that compiles
 	if err != nil {
-		return err
+		return false, err
 	}
 	if validRegexp { // If it is a regular expression, use it as is
 		regularExpression = substring
 	} else { // If it is a literal string, use it as a word boundary
-		regularExpression = fmt.Sprintf(`(?i)\b%s\b\s*[:=]\s*([0-9]+\.[0-9]+\.[0-9]+)`, substring)
+		regularExpression = fmt.Sprintf(`(?i)\b%s\b\s*[:=]\s*["']?([0-9]+\.[0-9]+\.[0-9]+)["']?`, substring)
 	}
 	versionRegex, err := regexp.Compile(regularExpression)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for scanner.Scan() {
@@ -208,6 +213,9 @@ func updateVersionOfFiles(filePath, substring, newVersion string) error {
 			oldVersion := strings.TrimSpace(match[1])
 			// Replace the old version with the new version
 			newLine := strings.Replace(line, oldVersion, newVersion, 1)
+			if newLine != line {
+				modified = true
+			}
 			lines = append(lines, newLine)
 		} else {
 			// The line does not contain the substring given by 'substring'
@@ -222,7 +230,7 @@ func updateVersionOfFiles(filePath, substring, newVersion string) error {
 		file.WriteString(line + "\n")
 	}
 
-	return nil
+	return modified, nil
 }
 
 func isARegExp(s string) (bool, error) {

--- a/internal/app/gommitizen/config/version_test.go
+++ b/internal/app/gommitizen/config/version_test.go
@@ -35,59 +35,66 @@ func TestNewConfigVersion(t *testing.T) {
 
 func TestUpdateVersionOfFiles(t *testing.T) {
 	tests := []struct {
-		name        string
-		content     string
-		substring   string
-		newVersion  string
-		wantContent string
+		name         string
+		content      string
+		substring    string
+		newVersion   string
+		wantContent  string
+		wantMatched  bool
 		wantModified bool
 	}{
 		{
-			name:        "unquoted YAML value",
-			content:     "image: myapp\n  tag: 0.8.2\nreplicas: 3\n",
-			substring:   "tag",
-			newVersion:  "0.9.0",
-			wantContent: "image: myapp\n  tag: 0.9.0\nreplicas: 3\n",
+			name:         "unquoted YAML value",
+			content:      "image: myapp\n  tag: 0.8.2\nreplicas: 3\n",
+			substring:    "tag",
+			newVersion:   "0.9.0",
+			wantContent:  "image: myapp\n  tag: 0.9.0\nreplicas: 3\n",
+			wantMatched:  true,
 			wantModified: true,
 		},
 		{
-			name:        "double-quoted YAML value",
-			content:     "image: myapp\n  tag: \"0.8.2\"\nreplicas: 3\n",
-			substring:   "tag",
-			newVersion:  "0.9.0",
-			wantContent: "image: myapp\n  tag: \"0.9.0\"\nreplicas: 3\n",
+			name:         "double-quoted YAML value",
+			content:      "image: myapp\n  tag: \"0.8.2\"\nreplicas: 3\n",
+			substring:    "tag",
+			newVersion:   "0.9.0",
+			wantContent:  "image: myapp\n  tag: \"0.9.0\"\nreplicas: 3\n",
+			wantMatched:  true,
 			wantModified: true,
 		},
 		{
-			name:        "single-quoted YAML value",
-			content:     "image: myapp\n  tag: '0.8.2'\nreplicas: 3\n",
-			substring:   "tag",
-			newVersion:  "0.9.0",
-			wantContent: "image: myapp\n  tag: '0.9.0'\nreplicas: 3\n",
+			name:         "single-quoted YAML value",
+			content:      "image: myapp\n  tag: '0.8.2'\nreplicas: 3\n",
+			substring:    "tag",
+			newVersion:   "0.9.0",
+			wantContent:  "image: myapp\n  tag: '0.9.0'\nreplicas: 3\n",
+			wantMatched:  true,
 			wantModified: true,
 		},
 		{
-			name:        "no match returns false",
-			content:     "image: myapp\nreplicas: 3\n",
-			substring:   "tag",
-			newVersion:  "0.9.0",
-			wantContent: "image: myapp\nreplicas: 3\n",
+			name:         "no match returns false",
+			content:      "image: myapp\nreplicas: 3\n",
+			substring:    "tag",
+			newVersion:   "0.9.0",
+			wantContent:  "image: myapp\nreplicas: 3\n",
+			wantMatched:  false,
 			wantModified: false,
 		},
 		{
-			name:        "same version returns false",
-			content:     "  tag: 0.9.0\n",
-			substring:   "tag",
-			newVersion:  "0.9.0",
-			wantContent: "  tag: 0.9.0\n",
+			name:         "same version returns false",
+			content:      "  tag: 0.9.0\n",
+			substring:    "tag",
+			newVersion:   "0.9.0",
+			wantContent:  "  tag: 0.9.0\n",
+			wantMatched:  true,
 			wantModified: false,
 		},
 		{
-			name:        "equals sign separator",
-			content:     "version = 1.2.3\n",
-			substring:   "version",
-			newVersion:  "1.3.0",
-			wantContent: "version = 1.3.0\n",
+			name:         "equals sign separator",
+			content:      "version = 1.2.3\n",
+			substring:    "version",
+			newVersion:   "1.3.0",
+			wantContent:  "version = 1.3.0\n",
+			wantMatched:  true,
 			wantModified: true,
 		},
 	}
@@ -100,9 +107,12 @@ func TestUpdateVersionOfFiles(t *testing.T) {
 				t.Fatalf("failed to write temp file: %v", err)
 			}
 
-			modified, err := updateVersionOfFiles(tmpFile, tt.substring, tt.newVersion)
+			matched, modified, err := updateVersionOfFiles(tmpFile, tt.substring, tt.newVersion)
 			if err != nil {
 				t.Fatalf("updateVersionOfFiles() error = %v", err)
+			}
+			if matched != tt.wantMatched {
+				t.Errorf("updateVersionOfFiles() matched = %v, want %v", matched, tt.wantMatched)
 			}
 			if modified != tt.wantModified {
 				t.Errorf("updateVersionOfFiles() modified = %v, want %v", modified, tt.wantModified)

--- a/internal/app/gommitizen/config/version_test.go
+++ b/internal/app/gommitizen/config/version_test.go
@@ -33,6 +33,180 @@ func TestNewConfigVersion(t *testing.T) {
 	}
 }
 
+func TestUpdateVersionOfFiles(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		substring   string
+		newVersion  string
+		wantContent string
+		wantModified bool
+	}{
+		{
+			name:        "unquoted YAML value",
+			content:     "image: myapp\n  tag: 0.8.2\nreplicas: 3\n",
+			substring:   "tag",
+			newVersion:  "0.9.0",
+			wantContent: "image: myapp\n  tag: 0.9.0\nreplicas: 3\n",
+			wantModified: true,
+		},
+		{
+			name:        "double-quoted YAML value",
+			content:     "image: myapp\n  tag: \"0.8.2\"\nreplicas: 3\n",
+			substring:   "tag",
+			newVersion:  "0.9.0",
+			wantContent: "image: myapp\n  tag: \"0.9.0\"\nreplicas: 3\n",
+			wantModified: true,
+		},
+		{
+			name:        "single-quoted YAML value",
+			content:     "image: myapp\n  tag: '0.8.2'\nreplicas: 3\n",
+			substring:   "tag",
+			newVersion:  "0.9.0",
+			wantContent: "image: myapp\n  tag: '0.9.0'\nreplicas: 3\n",
+			wantModified: true,
+		},
+		{
+			name:        "no match returns false",
+			content:     "image: myapp\nreplicas: 3\n",
+			substring:   "tag",
+			newVersion:  "0.9.0",
+			wantContent: "image: myapp\nreplicas: 3\n",
+			wantModified: false,
+		},
+		{
+			name:        "same version returns false",
+			content:     "  tag: 0.9.0\n",
+			substring:   "tag",
+			newVersion:  "0.9.0",
+			wantContent: "  tag: 0.9.0\n",
+			wantModified: false,
+		},
+		{
+			name:        "equals sign separator",
+			content:     "version = 1.2.3\n",
+			substring:   "version",
+			newVersion:  "1.3.0",
+			wantContent: "version = 1.3.0\n",
+			wantModified: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "testfile.yaml")
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			if err != nil {
+				t.Fatalf("failed to write temp file: %v", err)
+			}
+
+			modified, err := updateVersionOfFiles(tmpFile, tt.substring, tt.newVersion)
+			if err != nil {
+				t.Fatalf("updateVersionOfFiles() error = %v", err)
+			}
+			if modified != tt.wantModified {
+				t.Errorf("updateVersionOfFiles() modified = %v, want %v", modified, tt.wantModified)
+			}
+
+			got, err := os.ReadFile(tmpFile)
+			if err != nil {
+				t.Fatalf("failed to read result file: %v", err)
+			}
+			if string(got) != tt.wantContent {
+				t.Errorf("file content = %q, want %q", string(got), tt.wantContent)
+			}
+		})
+	}
+}
+
+func TestUpdateVersionWithVersionFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a YAML file with a quoted version
+	yamlContent := "image: myapp\n  tag: \"1.0.0\"\n"
+	yamlPath := filepath.Join(tempDir, "values.yaml")
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write yaml file: %v", err)
+	}
+
+	// Create a ConfigVersion pointing to the YAML file
+	cv := &ConfigVersion{
+		dirPath:      tempDir,
+		Version:      "1.0.0",
+		Commit:       "abc123",
+		VersionFiles: []string{"values.yaml:tag"},
+		Alias:        "test",
+	}
+	// Save the .version.json so UpdateVersion can re-save it
+	data, err := json.MarshalIndent(cv, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(tempDir, defaultFileName), data, 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	modifiedFiles, err := cv.UpdateVersion("2.0.0", "def456")
+	if err != nil {
+		t.Fatalf("UpdateVersion() error = %v", err)
+	}
+
+	// Should include both .version.json and values.yaml
+	if len(modifiedFiles) != 2 {
+		t.Fatalf("expected 2 modified files, got %d: %v", len(modifiedFiles), modifiedFiles)
+	}
+
+	// Verify the YAML file was actually updated
+	got, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("failed to read yaml file: %v", err)
+	}
+	expected := "image: myapp\n  tag: \"2.0.0\"\n"
+	if string(got) != expected {
+		t.Errorf("yaml content = %q, want %q", string(got), expected)
+	}
+}
+
+func TestUpdateVersionNoMatchExcludedFromModified(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create a YAML file WITHOUT a matching key
+	yamlContent := "image: myapp\nreplicas: 3\n"
+	yamlPath := filepath.Join(tempDir, "values.yaml")
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write yaml file: %v", err)
+	}
+
+	cv := &ConfigVersion{
+		dirPath:      tempDir,
+		Version:      "1.0.0",
+		Commit:       "abc123",
+		VersionFiles: []string{"values.yaml:tag"},
+		Alias:        "test",
+	}
+	data, err := json.MarshalIndent(cv, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(tempDir, defaultFileName), data, 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	modifiedFiles, err := cv.UpdateVersion("2.0.0", "def456")
+	if err != nil {
+		t.Fatalf("UpdateVersion() error = %v", err)
+	}
+
+	// Should only include .version.json, NOT values.yaml
+	if len(modifiedFiles) != 1 {
+		t.Fatalf("expected 1 modified file, got %d: %v", len(modifiedFiles), modifiedFiles)
+	}
+}
+
 func TestRead(t *testing.T) {
 	// Crear un archivo JSON temporal
 	tempDir := t.TempDir()

--- a/internal/pkg/cmd/get.go
+++ b/internal/pkg/cmd/get.go
@@ -30,8 +30,8 @@ information and all the information saved in the config file.`,
 			"# or just:\n" +
 			"gommitizen get version\n",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if output != "json" && output != "yaml" && output != "plain" {
-				return fmt.Errorf("invalid output format: %s, supported values: json, yaml, plain", output)
+			if output != "json" && output != "yaml" && output != "plain" && output != "raw" {
+				return fmt.Errorf("invalid output format: %s, supported values: json, yaml, plain, raw", output)
 			}
 			return nil
 		},
@@ -43,7 +43,7 @@ information and all the information saved in the config file.`,
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&output, getOutputFlagName, "o", "plain", "select the output format {json, yaml, plain}")
+	cmd.PersistentFlags().StringVarP(&output, getOutputFlagName, "o", "plain", "select the output format {json, yaml, plain, raw}")
 	cmd.PersistentFlags().StringVarP(&alias, getAliasFlagName, "a", "", "a alias to look for a project to show information")
 
 	cmd.AddCommand(getAllCmd())
@@ -151,7 +151,7 @@ func projectsRun(dirPath string, alias string, output string, filter []string) {
 	}
 
 	// Print directly to stdout for structured formats to allow piping to tools like yq
-	if output == "json" || output == "yaml" {
+	if output == "json" || output == "yaml" || output == "raw" {
 		fmt.Println(str)
 	} else {
 		slog.Info(str)


### PR DESCRIPTION
## Summary

- **Fix regex for quoted YAML values:** The auto-generated regex for literal keys in `version_files` now matches quoted values (`tag: "0.8.2"` and `tag: '0.8.2'`) in addition to unquoted ones (`tag: 0.8.2`)
- **Return modification status:** `updateVersionOfFiles` now returns a `bool` indicating whether the file was actually changed, preventing silent no-ops where files appeared updated but weren't
- **Conditional modified files list:** Only truly modified files are included in `modifiedFiles` and committed; a warning is logged when no pattern match is found

## Test plan

- [x] `go build ./...` compiles successfully
- [x] New `TestUpdateVersionOfFiles` table-driven tests cover unquoted, double-quoted, single-quoted, no-match, same-version, and equals-sign cases
- [x] `TestUpdateVersionWithVersionFiles` integration test verifies quoted YAML values are updated via `UpdateVersion`
- [x] `TestUpdateVersionNoMatchExcludedFromModified` verifies unmatched files are excluded from modified list
- [ ] Manual test: create `.version.json` with `version_files` pointing to a YAML with `tag: "0.8.2"`, run bump, verify YAML is updated and included in commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches version-bumping logic and file rewriting behavior, which could affect which files are committed/updated if the matching regex is too broad or too narrow. Changes are localized and covered by new unit/integration tests, lowering risk.
> 
> **Overview**
> Fixes `version_files` updates to match semver values that may be quoted (e.g., `tag: "1.2.3"` / `tag: '1.2.3'`) and changes `updateVersionOfFiles` to report whether a match was found and whether the file was actually modified.
> 
> `UpdateVersion` now only includes truly changed version files in its `modifiedFiles` list (logging *warn* on no match and *info* on already-up-to-date), and avoids rewriting files when no changes occurred. Adds a new `-o raw` output mode for `gommitizen get` that prints deterministic, script-friendly values (with stdout printing enabled for `raw`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61988fae49537380279f12d7d5731d467cefb04. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->