### PR TITLE
fix: confirm bumps outside main branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Increment the version of the project according to the conventional commits speci
 
 - `-i`, `--increment`: manually specify the desired increment {MAJOR, MINOR, PATCH}
 
+- `-y`, `--yes`: automatically confirm a bump outside main or master, including detached HEAD
+
 
 
 **Examples of usage:**

--- a/internal/app/gommitizen/git/git.go
+++ b/internal/app/gommitizen/git/git.go
@@ -58,6 +58,18 @@ func GetLastCommit() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+func GetCurrentBranch(dirPath string) (string, error) {
+	cmd := []string{"git", "-C", dirPath, "rev-parse", "--abbrev-ref", "HEAD"}
+	slog.Debug(fmt.Sprintf("exec: %s", strings.Join(cmd, " ")))
+
+	output, err := exec.Command(cmd[0], cmd[1:]...).Output()
+	if err != nil {
+		return "", fmt.Errorf("fail %s: %v", strings.Join(cmd, " "), err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
 // https://git-scm.com/docs/pretty-formats
 func GetCommits(fromCommit string, fromPath string) ([]Commit, error) {
 	pretty := `--pretty=format:'%H||%ad||%s'`

--- a/internal/app/gommitizen/git/git.go
+++ b/internal/app/gommitizen/git/git.go
@@ -67,7 +67,12 @@ func GetCurrentBranch(dirPath string) (string, error) {
 		return "", fmt.Errorf("fail %s: %v", strings.Join(cmd, " "), err)
 	}
 
-	return strings.TrimSpace(string(output)), nil
+	branch := strings.TrimSpace(string(output))
+	if branch == "HEAD" {
+		return "", nil
+	}
+
+	return branch, nil
 }
 
 // https://git-scm.com/docs/pretty-formats

--- a/internal/app/gommitizen/git/git_test.go
+++ b/internal/app/gommitizen/git/git_test.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetCurrentBranch(t *testing.T) {
+	repoPath := t.TempDir()
+	runGitForBranchTest(t, repoPath, "init", "-b", "feature/example")
+
+	trackedFile := filepath.Join(repoPath, "tracked.txt")
+	if err := os.WriteFile(trackedFile, []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	runGitForBranchTest(t, repoPath, "add", "tracked.txt")
+	runGitForBranchTest(
+		t,
+		repoPath,
+		"-c", "user.name=Gommitizen Test",
+		"-c", "user.email=gommitizen@example.com",
+		"-c", "commit.gpgsign=false",
+		"commit", "-m", "initial commit",
+	)
+
+	branch, err := GetCurrentBranch(repoPath)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch() unexpected error = %v", err)
+	}
+	if branch != "feature/example" {
+		t.Fatalf("GetCurrentBranch() = %q, want %q", branch, "feature/example")
+	}
+
+	runGitForBranchTest(t, repoPath, "checkout", "--detach")
+	branch, err = GetCurrentBranch(repoPath)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch() on detached HEAD unexpected error = %v", err)
+	}
+	if branch != "" {
+		t.Fatalf("GetCurrentBranch() on detached HEAD = %q, want empty branch", branch)
+	}
+}
+
+func runGitForBranchTest(t *testing.T, repoPath string, args ...string) string {
+	t.Helper()
+
+	commandArgs := append([]string{"-C", repoPath}, args...)
+	output, err := exec.Command("git", commandArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(commandArgs, " "), err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}

--- a/internal/pkg/cmd/bump.go
+++ b/internal/pkg/cmd/bump.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -51,9 +54,25 @@ func bumpCmd() *cobra.Command {
 				strings.Join(validIncrements, ", "),
 			)
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			dirPath := cmd.Root().Flag(rootDirPathFlagName).Value.String()
+
+			branch, err := git.GetCurrentBranch(dirPath)
+			if err != nil {
+				return fmt.Errorf("current branch: %w", err)
+			}
+
+			continueBump, err := confirmBumpOnBranch(branch, cmd.InOrStdin(), cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if !continueBump {
+				slog.Info("Bump cancelled")
+				return nil
+			}
+
 			bumpRun(dirPath, createChangelog, strings.ToLower(incrementType))
+			return nil
 		},
 	}
 
@@ -61,6 +80,31 @@ func bumpCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&incrementType, "increment", "i", "", "manually specify the desired increment {MAJOR, MINOR, PATCH}")
 
 	return cmd
+}
+
+func confirmBumpOnBranch(branch string, input io.Reader, output io.Writer) (bool, error) {
+	if branch == "main" || branch == "master" {
+		return true, nil
+	}
+
+	fmt.Fprintf(
+		output,
+		"Warning: you are running a bump on branch %q, not main or master. A squash merge can make the stored commit unavailable and prevent future bumps.\n",
+		branch,
+	)
+	fmt.Fprint(output, "Continue with the bump? [y/N] ")
+
+	answer, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("read bump confirmation: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func bumpRun(dirPath string, createChangelog bool, incrementType string) {

--- a/internal/pkg/cmd/bump.go
+++ b/internal/pkg/cmd/bump.go
@@ -22,6 +22,7 @@ func bumpCmd() *cobra.Command {
 	var validIncrements = []string{"MAJOR", "MINOR", "PATCH"}
 	var incrementType string
 	var createChangelog bool
+	var assumeYes bool
 
 	cmd := &cobra.Command{
 		Use:   "bump",
@@ -62,7 +63,7 @@ func bumpCmd() *cobra.Command {
 				return fmt.Errorf("current branch: %w", err)
 			}
 
-			continueBump, err := confirmBumpOnBranch(branch, cmd.InOrStdin(), cmd.OutOrStdout())
+			continueBump, err := confirmBumpOnBranch(branch, assumeYes, cmd.InOrStdin(), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -78,25 +79,42 @@ func bumpCmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&createChangelog, "changelog", "c", false, "generate the changelog for the newest version")
 	cmd.Flags().StringVarP(&incrementType, "increment", "i", "", "manually specify the desired increment {MAJOR, MINOR, PATCH}")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "automatically confirm a bump outside main or master, including detached HEAD")
 
 	return cmd
 }
 
-func confirmBumpOnBranch(branch string, input io.Reader, output io.Writer) (bool, error) {
+func confirmBumpOnBranch(branch string, assumeYes bool, input io.Reader, output io.Writer) (bool, error) {
 	if branch == "main" || branch == "master" {
 		return true, nil
 	}
 
-	fmt.Fprintf(
-		output,
-		"Warning: you are running a bump on branch %q, not main or master. A squash merge can make the stored commit unavailable and prevent future bumps.\n",
-		branch,
-	)
+	if branch == "" {
+		fmt.Fprintln(
+			output,
+			"Warning: you are running a bump from a detached HEAD. A squash merge can make the stored commit unavailable and prevent future bumps.",
+		)
+	} else {
+		fmt.Fprintf(
+			output,
+			"Warning: you are running a bump on branch %q, not main or master. A squash merge can make the stored commit unavailable and prevent future bumps.\n",
+			branch,
+		)
+	}
+
+	if assumeYes {
+		return true, nil
+	}
+
 	fmt.Fprint(output, "Continue with the bump? [y/N] ")
 
 	answer, err := bufio.NewReader(input).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("read bump confirmation: %w", err)
+	}
+	if errors.Is(err, io.EOF) && strings.TrimSpace(answer) == "" {
+		fmt.Fprintln(output)
+		return false, errors.New("bump confirmation requires input; rerun with --yes to continue")
 	}
 
 	switch strings.ToLower(strings.TrimSpace(answer)) {

--- a/internal/pkg/cmd/bump_test.go
+++ b/internal/pkg/cmd/bump_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestConfirmBumpOnBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		branch     string
+		input      string
+		want       bool
+		wantPrompt bool
+	}{
+		{name: "main continues without prompting", branch: "main", want: true},
+		{name: "master continues without prompting", branch: "master", want: true},
+		{name: "feature branch accepts y", branch: "feature/example", input: "y\n", want: true, wantPrompt: true},
+		{name: "feature branch accepts yes case insensitively", branch: "feature/example", input: "YES\n", want: true, wantPrompt: true},
+		{name: "feature branch rejects n", branch: "feature/example", input: "n\n", wantPrompt: true},
+		{name: "feature branch defaults to no", branch: "feature/example", input: "\n", wantPrompt: true},
+		{name: "feature branch defaults to no on eof", branch: "feature/example", wantPrompt: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			got, err := confirmBumpOnBranch(tt.branch, strings.NewReader(tt.input), &output)
+			if err != nil {
+				t.Fatalf("confirmBumpOnBranch() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("confirmBumpOnBranch() = %v, want %v", got, tt.want)
+			}
+
+			prompted := output.Len() > 0
+			if prompted != tt.wantPrompt {
+				t.Errorf("confirmBumpOnBranch() prompted = %v, want %v", prompted, tt.wantPrompt)
+			}
+			if tt.wantPrompt && !strings.Contains(output.String(), tt.branch) {
+				t.Errorf("prompt %q does not include branch %q", output.String(), tt.branch)
+			}
+		})
+	}
+}

--- a/internal/pkg/cmd/bump_test.go
+++ b/internal/pkg/cmd/bump_test.go
@@ -8,38 +8,48 @@ import (
 
 func TestConfirmBumpOnBranch(t *testing.T) {
 	tests := []struct {
-		name       string
-		branch     string
-		input      string
-		want       bool
-		wantPrompt bool
+		name               string
+		branch             string
+		assumeYes          bool
+		input              string
+		want               bool
+		wantErr            string
+		wantOutputContains string
+		wantPrompt         bool
 	}{
 		{name: "main continues without prompting", branch: "main", want: true},
 		{name: "master continues without prompting", branch: "master", want: true},
-		{name: "feature branch accepts y", branch: "feature/example", input: "y\n", want: true, wantPrompt: true},
-		{name: "feature branch accepts yes case insensitively", branch: "feature/example", input: "YES\n", want: true, wantPrompt: true},
-		{name: "feature branch rejects n", branch: "feature/example", input: "n\n", wantPrompt: true},
-		{name: "feature branch defaults to no", branch: "feature/example", input: "\n", wantPrompt: true},
-		{name: "feature branch defaults to no on eof", branch: "feature/example", wantPrompt: true},
+		{name: "feature branch accepts y", branch: "feature/example", input: "y\n", want: true, wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "feature branch accepts y at eof", branch: "feature/example", input: "y", want: true, wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "feature branch accepts yes case insensitively", branch: "feature/example", input: "YES\n", want: true, wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "feature branch rejects n", branch: "feature/example", input: "n\n", wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "feature branch defaults to no", branch: "feature/example", input: "\n", wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "feature branch accepts yes flag", branch: "feature/example", assumeYes: true, want: true, wantOutputContains: "feature/example"},
+		{name: "feature branch reports eof", branch: "feature/example", wantErr: "rerun with --yes", wantOutputContains: "feature/example", wantPrompt: true},
+		{name: "detached HEAD prompts safely", input: "n\n", wantOutputContains: "detached HEAD", wantPrompt: true},
+		{name: "detached HEAD is identified", assumeYes: true, want: true, wantOutputContains: "detached HEAD"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var output bytes.Buffer
-			got, err := confirmBumpOnBranch(tt.branch, strings.NewReader(tt.input), &output)
-			if err != nil {
-				t.Fatalf("confirmBumpOnBranch() error = %v", err)
+			got, err := confirmBumpOnBranch(tt.branch, tt.assumeYes, strings.NewReader(tt.input), &output)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("confirmBumpOnBranch() unexpected error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("confirmBumpOnBranch() error = %v, want error containing %q", err, tt.wantErr)
 			}
 			if got != tt.want {
 				t.Errorf("confirmBumpOnBranch() = %v, want %v", got, tt.want)
 			}
 
-			prompted := output.Len() > 0
+			prompted := strings.Contains(output.String(), "Continue with the bump?")
 			if prompted != tt.wantPrompt {
 				t.Errorf("confirmBumpOnBranch() prompted = %v, want %v", prompted, tt.wantPrompt)
 			}
-			if tt.wantPrompt && !strings.Contains(output.String(), tt.branch) {
-				t.Errorf("prompt %q does not include branch %q", output.String(), tt.branch)
+			if !strings.Contains(output.String(), tt.wantOutputContains) {
+				t.Errorf("output %q does not contain %q", output.String(), tt.wantOutputContains)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- detect the active Git branch before starting a bump
- warn and request confirmation outside `main`/`master`, with clear detached-HEAD handling
- add `--yes`/`-y` for intentional non-interactive execution
- report closed stdin with actionable guidance instead of silently cancelling

## Testing

- `go test ./internal/pkg/cmd ./internal/app/gommitizen/git`
- `go run ./cmd/gommitizen bump --help`
- `go test ./...` still reaches the pre-existing `config.TestRead` failure because that test passes a directory to `ReadConfigVersion`

Closes #70